### PR TITLE
Remote PR Set #2: Introduce RemoteCommands

### DIFF
--- a/TidepoolServiceKit/TidepoolService.swift
+++ b/TidepoolServiceKit/TidepoolService.swift
@@ -394,6 +394,15 @@ extension TidepoolService: RemoteDataService {
             }
         }
     }
+    
+    public func commandFromPushNotification(_ notification: [String: AnyObject]) async throws -> RemoteCommand {
+        
+        enum TidepoolPushNotificationError: LocalizedError {
+            case remoteCommandsNotSupported
+        }
+        
+        throw TidepoolPushNotificationError.remoteCommandsNotSupported
+    }
 
     func calculateSettingsData(_ stored: [StoredSettings], for userId: String, hostIdentifier: String, hostVersion: String) -> ([TDatum], [TDatum], TControllerSettingsDatum?, TCGMSettingsDatum?, TPumpSettingsDatum?, TPumpSettingsOverrideDeviceEventDatum?) {
         var created: [TDatum] = []


### PR DESCRIPTION
This PR is part of the below set that should be merged together. This one will use "RemoteCommands", a protocol for interacting with the remote services that is the source of the RemoteCommand. This will lay the groundwork for remote 2.0 commands.

* Loop: https://github.com/LoopKit/Loop/pull/1934
* LoopKit: https://github.com/LoopKit/LoopKit/pull/455
* NightscoutService: https://github.com/ps2/NightscoutService/pull/33
* TidepoolService: https://github.com/LoopKit/TidepoolService/pull/4