### PR TITLE
enable removal of non-pump insulin from Tidepool

### DIFF
--- a/TidepoolServiceKit/Extensions/DoseEntry.swift
+++ b/TidepoolServiceKit/Extensions/DoseEntry.swift
@@ -301,9 +301,7 @@ extension DoseEntry {
         case .basal:
             return [datumSelector(for: TScheduledBasalDatum.self)]
         case .bolus:
-            if manuallyEntered {
-                return [datumSelector(for: TInsulinDatum.self)]
-            } else if automatic != true {
+            if automatic != true {
                 return [datumSelector(for: TNormalBolusDatum.self)]
             } else {
                 return [datumSelector(for: TAutomatedBolusDatum.self)]


### PR DESCRIPTION
## Purpose:
As currently configured, the `tidepool-merge` branch properly uploads to Tidepool any non-pump insulin entered in the Loop app or added to Apple Health.

However, when that insulin is deleted from the Loop phone, it remains in the Tidepool record.

## Proposed solution

The code modification in this PR has been tested and it does work. It may not be the preferred solution.
I am happy to make a different modification and test it.

### Tests
* add non-pump insulin in Loop
   * appears in Tidepool as manual dose
* delete non-pump insulin in Loop
   * disappears from in Tidepool display (after refreshing web browser)
* add insulin to Apple Heath on Loop phone
   * appears in Tidepool as manual dose
* delete insulin from Apple Heath on Loop phone
   * disappears from in Tidepool display (after refreshing web browser)

(Off topic, but with same test observed the expected behavior on Nightscout site too).
