### PR TITLE
Translations, localizable.xcstrings (Multilingual)

### DIFF
--- a/TidepoolServiceKit/Localizable.xcstrings
+++ b/TidepoolServiceKit/Localizable.xcstrings
@@ -227,8 +227,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Missing DataSet Id"
+            "state" : "translated",
+            "value" : "Chýbajúce ID dátového súboru"
           }
         },
         "sv" : {
@@ -489,7 +489,7 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Tidepool"
           }
         },
@@ -620,8 +620,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Tidepool Service Authorization"
+            "state" : "translated",
+            "value" : "Autorizácia služby Tidepool"
           }
         },
         "sv" : {
@@ -751,8 +751,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
+            "state" : "translated",
+            "value" : "Služba Tidepool už nie je autorizovaná. Prejdite do nastavení služby Tidepool a znovu sa overte."
           }
         },
         "sv" : {

--- a/TidepoolServiceKit/Localizable.xcstrings
+++ b/TidepoolServiceKit/Localizable.xcstrings
@@ -124,12 +124,6 @@
             "value" : "Lỗi cấu hình"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Configuration Error"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -261,12 +255,6 @@
             "value" : "Thiếu Id bộ dữ liệu"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missing DataSet Id"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -395,12 +383,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "OK"
           }
         },
@@ -535,12 +517,6 @@
             "value" : "Tidepool"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tidepool"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -672,12 +648,6 @@
             "value" : "Ủy quyền dịch vụ Tidepool"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tidepool Service Authorization"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -807,12 +777,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dịch vụ Tidepool không còn được ủy quyền. Vui lòng vào cài đặt Dịch vụ Tidepool và xác thực lại."
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
         "zh-Hans" : {

--- a/TidepoolServiceKit/Localizable.xcstrings
+++ b/TidepoolServiceKit/Localizable.xcstrings
@@ -198,7 +198,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ontbrekende Gegevensset Id"
+            "value" : "Ontbrekende gegevensset Id"
           }
         },
         "pl" : {
@@ -591,7 +591,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tidepool Service Autorisatie"
+            "value" : "Tidepool service autorisatie"
           }
         },
         "pl" : {

--- a/TidepoolServiceKit/Localizable.xcstrings
+++ b/TidepoolServiceKit/Localizable.xcstrings
@@ -88,6 +88,12 @@
             "value" : "Configuration Error"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Configuration Error"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -214,6 +220,12 @@
           }
         },
         "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Missing DataSet Id"
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Missing DataSet Id"
@@ -350,6 +362,12 @@
             "value" : "OK"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -476,6 +494,12 @@
           }
         },
         "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tidepool"
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Tidepool"
@@ -612,6 +636,12 @@
             "value" : "Tidepool Service Authorization"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tidepool Service Authorization"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -738,6 +768,12 @@
           }
         },
         "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."

--- a/TidepoolServiceKit/Localizable.xcstrings
+++ b/TidepoolServiceKit/Localizable.xcstrings
@@ -6,14 +6,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Configuration Error"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chyba konfigurace"
           }
         },
         "da" : {
@@ -36,7 +30,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Configuration Error"
           }
         },
@@ -54,7 +48,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Configuration Error"
           }
         },
@@ -62,12 +56,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Errore di configurazione"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurasjonsfeil"
           }
         },
         "nb-NO" : {
@@ -96,14 +84,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Configuration Error"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare de configurare"
           }
         },
         "ru" : {
@@ -155,7 +137,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         },
@@ -173,13 +155,13 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         },
@@ -191,13 +173,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         },
@@ -205,12 +187,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ID del set di dati mancante"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mangler DataSet-ID"
           }
         },
         "nb-NO" : {
@@ -239,14 +215,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lipsește Id DataSet"
           }
         },
         "ru" : {
@@ -269,7 +239,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         },
@@ -287,7 +257,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Missing DataSet Id"
           }
         }
@@ -299,13 +269,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "موافق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "value" : "حسناً"
           }
         },
         "da" : {
@@ -328,7 +292,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -340,13 +304,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "תקין"
+            "state" : "new",
+            "value" : "OK"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -354,18 +318,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ok"
           }
         },
         "nb-NO" : {
@@ -377,12 +329,12 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ok"
+            "value" : "OK"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -394,20 +346,14 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "ОК"
           }
         },
         "sk" : {
@@ -443,7 +389,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的"
+            "value" : "Ok"
           }
         }
       }
@@ -453,67 +399,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidepool"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidepool"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
@@ -531,7 +465,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
@@ -543,19 +477,13 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidepool"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
@@ -573,7 +501,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         },
@@ -591,7 +519,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool"
           }
         }
@@ -602,7 +530,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
           }
         },
@@ -620,13 +548,13 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
           }
         },
@@ -638,13 +566,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
           }
         },
@@ -652,12 +580,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autorizzazione al servizio Tidepool"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisasjon av Tidepool-tjenesten"
           }
         },
         "nb-NO" : {
@@ -686,14 +608,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorizarea serviciului Tidepool"
           }
         },
         "ru" : {
@@ -716,7 +632,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool Service Authorization"
           }
         },
@@ -734,8 +650,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidepool 服务授权"
+            "state" : "new",
+            "value" : "Tidepool Service Authorization"
           }
         }
       }
@@ -745,7 +661,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
@@ -757,19 +673,19 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
@@ -781,13 +697,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
@@ -795,12 +711,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il servizio Tidepool non è più autorizzato. Accedi alle impostazioni del servizio Tidepool e autenticati nuovamente."
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidepool-tjenesten er ikke lenger autorisert. Gå til innstillingene for Tidepool-tjenesten og godkjenn på nytt."
           }
         },
         "nb-NO" : {
@@ -829,14 +739,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Serviciul Tidepool nu mai este autorizat. Vă rugăm să navigați la setările serviciului Tidepool și să vă autentificați din nou."
           }
         },
         "ru" : {
@@ -859,7 +763,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         },
@@ -877,7 +781,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate."
           }
         }

--- a/TidepoolServiceKitUI/Localizable.xcstrings
+++ b/TidepoolServiceKitUI/Localizable.xcstrings
@@ -124,12 +124,6 @@
             "value" : "Bạn có chắc là bạn muốn xóa bỏ dịch vụ này?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to delete this service?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -259,12 +253,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đóng"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close"
           }
         },
         "zh-Hans" : {
@@ -398,12 +386,6 @@
             "value" : "Xóa dịch vụ"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete Service"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -533,12 +515,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Môi trường"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Environment"
           }
         },
         "zh-Hans" : {
@@ -672,12 +648,6 @@
             "value" : "Đăng nhập với"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Logged in as"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -807,12 +777,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đăng nhập"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Login"
           }
         },
         "zh-Hans" : {
@@ -946,12 +910,6 @@
             "value" : "Thu hồi token"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Revoke token"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -1081,12 +1039,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bạn chưa đăng nhập."
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You are not logged in."
           }
         },
         "zh-Hans" : {

--- a/TidepoolServiceKitUI/Localizable.xcstrings
+++ b/TidepoolServiceKitUI/Localizable.xcstrings
@@ -10,12 +10,6 @@
             "value" : "Are you sure you want to delete this service?"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opravdu chcete tuto službu smazat?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54,7 +48,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Are you sure you want to delete this service?"
           }
         },
@@ -62,12 +56,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sei sicuro di voler eliminare questo servizio?"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er du sikker på at du vil slette denne tjenesten?"
           }
         },
         "nb-NO" : {
@@ -98,12 +86,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Are you sure you want to delete this service?"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ești sigur că vrei să ștergi acest serviciu?"
           }
         },
         "ru" : {
@@ -191,8 +173,8 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "סגור"
+            "state" : "new",
+            "value" : "Close"
           }
         },
         "hu" : {
@@ -204,13 +186,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chiudi"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lukk"
+            "value" : "Fine"
           }
         },
         "nb-NO" : {
@@ -241,12 +217,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fechar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Închide"
           }
         },
         "ru" : {
@@ -302,12 +272,6 @@
             "value" : "Delete Service"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smazat službu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -346,7 +310,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Delete Service"
           }
         },
@@ -354,18 +318,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elimina Servizio"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Service"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slett tjeneste"
           }
         },
         "nb-NO" : {
@@ -394,14 +346,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Delete Service"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Șterge serviciul"
           }
         },
         "ru" : {
@@ -442,7 +388,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Delete Service"
           }
         }
@@ -453,7 +399,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
@@ -471,13 +417,13 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
@@ -489,13 +435,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
@@ -503,12 +449,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ambiente"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Miljø"
           }
         },
         "nb-NO" : {
@@ -537,19 +477,13 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mediu"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
@@ -567,7 +501,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         },
@@ -585,7 +519,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Environment"
           }
         }
@@ -596,7 +530,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
           }
         },
@@ -614,13 +548,13 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
           }
         },
@@ -632,13 +566,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
           }
         },
@@ -646,12 +580,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autenticato come"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innlogget som"
           }
         },
         "nb-NO" : {
@@ -680,14 +608,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autentificat ca"
           }
         },
         "ru" : {
@@ -710,7 +632,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Logged in as"
           }
         },
@@ -743,15 +665,9 @@
             "value" : "Login"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přihlásit se"
-          }
-        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Login"
           }
         },
@@ -775,7 +691,7 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Login"
           }
         },
@@ -787,20 +703,14 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Login"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Login"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logg Inn"
           }
         },
         "nb-NO" : {
@@ -817,7 +727,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Login"
           }
         },
@@ -831,12 +741,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Login"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autentificare"
           }
         },
         "ru" : {
@@ -888,7 +792,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         },
@@ -906,13 +810,13 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         },
@@ -924,13 +828,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         },
@@ -938,12 +842,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Revoca token"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilbakekall token"
           }
         },
         "nb-NO" : {
@@ -972,14 +870,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Revocare token"
           }
         },
         "ru" : {
@@ -1002,7 +894,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         },
@@ -1020,7 +912,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Revoke token"
           }
         }
@@ -1031,7 +923,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
           }
         },
@@ -1049,13 +941,13 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
           }
         },
@@ -1067,13 +959,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
           }
         },
@@ -1081,12 +973,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non sei autenticato."
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du er ikke innlogget."
           }
         },
         "nb-NO" : {
@@ -1115,14 +1001,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu ești autentificat/ă."
           }
         },
         "ru" : {
@@ -1145,7 +1025,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "You are not logged in."
           }
         },

--- a/TidepoolServiceKitUI/Localizable.xcstrings
+++ b/TidepoolServiceKitUI/Localizable.xcstrings
@@ -88,6 +88,12 @@
             "value" : "Are you sure you want to delete this service?"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this service?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -219,6 +225,12 @@
             "value" : "Fechar"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -345,6 +357,12 @@
           }
         },
         "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Service"
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete Service"
@@ -481,6 +499,12 @@
             "value" : "Environment"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Environment"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "new",
@@ -607,6 +631,12 @@
           }
         },
         "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Logged in as"
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Logged in as"
@@ -743,6 +773,12 @@
             "value" : "Login"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Login"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -874,6 +910,12 @@
             "value" : "Revoke token"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Revoke token"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1000,6 +1042,12 @@
           }
         },
         "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You are not logged in."
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "You are not logged in."

--- a/TidepoolServiceKitUI/Localizable.xcstrings
+++ b/TidepoolServiceKitUI/Localizable.xcstrings
@@ -489,8 +489,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Environment"
+            "state" : "translated",
+            "value" : "Prostredie"
           }
         },
         "sv" : {
@@ -620,8 +620,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Logged in as"
+            "state" : "translated",
+            "value" : "Prihlásený ako"
           }
         },
         "sv" : {
@@ -882,8 +882,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Revoke token"
+            "state" : "translated",
+            "value" : "Zrušiť token"
           }
         },
         "sv" : {
@@ -1013,8 +1013,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "You are not logged in."
+            "state" : "translated",
+            "value" : "Nie ste prihlásený."
           }
         },
         "sv" : {


### PR DESCRIPTION
Swedish and Dutch 100% and other languages not fully completed.   Created with Crowdin (= no parsing errors). 

Unfortunately there is also be an added configuration file, crowdin.yml. This file is only used by Crowdin, meaning it will not mess anything up with lokalise or the Loop Workspace. You can ignore it, when merging, but it would be easier to keep it (for future PRs).