### PR TITLE
Updated translations from lokalise on Sat Dec 27 14:50:21 PST 2025

### DIFF
--- a/TidepoolServiceKitUI/Localizable.xcstrings
+++ b/TidepoolServiceKitUI/Localizable.xcstrings
@@ -6,7 +6,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to delete this service?"
           }
         },
@@ -96,7 +96,7 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to delete this service?"
           }
         },
@@ -298,7 +298,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delete Service"
           }
         },
@@ -739,7 +739,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Login"
           }
         },
@@ -829,7 +829,7 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Login"
           }
         },


### PR DESCRIPTION
All changes are of the "No value added" variety.

"No value added" means:
* A key that was marked as "new" is marked as "translated" 
   * the key is not actually translated; it is same as source (English copied into the translated field for some languages) 
* If we later want to clean these up, we need to make the change in Xcode and then upload to lokalise with the `--replace-modified` field
* For now, just accept so that next import will be clean